### PR TITLE
ccls: Fix style error

### DIFF
--- a/Formula/ccls.rb
+++ b/Formula/ccls.rb
@@ -3,12 +3,12 @@ class Ccls < Formula
   homepage "https://github.com/MaskRay/ccls"
   if MacOS.version <= :el_capitan
     url "https://github.com/MaskRay/ccls.git",
-        :tag => "0.20180812",
-        :revision => "06aa25233567ae16a58a6f5237aacfd9e02aa29d"
+           :tag      => "0.20180812",
+           :revision => "06aa25233567ae16a58a6f5237aacfd9e02aa29d"
   else
     url "https://github.com/MaskRay/ccls.git",
-        :tag => "0.20181225.8",
-        :revision => "d275ed570d7ea26dd8d762b8d82bc4e295971154"
+           :tag      => "0.20181225.8",
+           :revision => "d275ed570d7ea26dd8d762b8d82bc4e295971154"
   end
   head "https://github.com/MaskRay/ccls.git"
 


### PR DESCRIPTION
Fixes the following:

```sh
➜ brew audit --strict Formula/ccls.rb
twlz0ne/ccls/ccls:
  * C: 6: col 9: Align the elements of a hash literal if they span more than one line.
  * C: 10: col 9: Align the elements of a hash literal if they span more than one line.
Error: 2 problems in 1 formula detected
```

Solved with `brew style --fix ccls`.